### PR TITLE
GH issue #48: Add data migration to update site contact email

### DIFF
--- a/db/liquibase/postgresql/changelogs/ascent-centraldb/centraldb-root.xml
+++ b/db/liquibase/postgresql/changelogs/ascent-centraldb/centraldb-root.xml
@@ -16,5 +16,11 @@
 	<changeSet author="rudi.demarco" id="tagDatabase_v2026.0" context="project-initialization" labels="task/baseline-changelog-sync-7">
 		<tagDatabase tag="version_2026.0" />
 	</changeSet>
+
+    <!-- Update to site contact email (data only change)-->
+    <include file="data-migrations/2026/20260323_issue-48_update-site-email.xml"/>
+	<changeSet author="rudi.demarco" id="tagDatabase_v2026.0.1" context="data-migration" labels="task/update-site-contact-email-issue-48">
+		<tagDatabase tag="version_2026.0.1" />
+	</changeSet>
 	
 </databaseChangeLog>

--- a/db/liquibase/postgresql/changelogs/ascent-centraldb/data-migrations/2026/20260323_issue-48_update-site-email.xml
+++ b/db/liquibase/postgresql/changelogs/ascent-centraldb/data-migrations/2026/20260323_issue-48_update-site-email.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <!-- Update site contact email for SouthDeKalb -->
+    <changeSet id="1" author="rudi.demarco">
+        <update schemaName="common" tableName="sites">
+            <column name="contact_email" value="ng@caltech.edu"/>
+            <where>site_number=11</where>
+        </update>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
I added a new subdirectory data-migrations/ under the ascent-centraldb/ directory for Liquibase changelogs for the central database. This new directory should only be used for data related changes that we want to track and audit in the source control Liquibase changelogs.

Since this is a new deployable change after the last tagged database deployment (baseline sync) and this change doesn't make any major breaking schema or related code changes, we can add a micro extension number to the existing tagged database version (v2026.0 -> 2026.0.1).

This is currently just on my branch development database. So, once this is merged it will need to be deployed to the main dev branch and production.