### PR TITLE
Bugfix/ae33 temp rh 83

### DIFF
--- a/services/r/ascentr/DESCRIPTION
+++ b/services/r/ascentr/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ascentr
 Type: Package
 Title: Tools for interacting with the ASCENT database
-Version: 0.1.19
+Version: 0.1.20
 Authors@R: c(
     person(
       "Sean", "Raffuse",

--- a/services/r/ascentr/NEWS
+++ b/services/r/ascentr/NEWS
@@ -1,3 +1,9 @@
+ascentr v0.1.20 (Release Date: 2026-06-15)
+==========================================
+
+Apply RIE correction to fragment ions in ACSM L2 data
+
+
 ascentr v0.1.19 (Release Date: 2026-06-01)
 ==========================================
 

--- a/services/r/ascentr/R/acsm.R
+++ b/services/r/ascentr/R/acsm.R
@@ -584,6 +584,14 @@ acsm_l2_from_files <- function(site, site_file, con) {
       rename(sample_datetime_UTC=sample_hour_UTC) 
   }
   
+  # As of June 2026, all fragment ions have to have RIE applied to them as a correction
+  # This will possibly be done upstream in future igor processing
+  org_rie <- 1.4
+  no3_rie <- 1.05
+  result <- result |>
+    mutate(across(c(m29, m43, m44, m55, m57, m60, m69, m71, m73), ~ .x / org_rie),
+           across(c(NO3_30, NO3_46), ~ .x / no3_rie))
+
   # Rearrange and rename for final export
   result <- result |>
     select(site_number, site_code, sample_datetime_UTC, sample_count, 

--- a/services/r/ascentr/inst/apps/ascent-operations/R/acsm.R
+++ b/services/r/ascentr/inst/apps/ascent-operations/R/acsm.R
@@ -22,8 +22,10 @@ acsmUI <- function(id) {
     collect()
   options <- colnames(df)
   
+  # Dryerstats: Don't include rh_3 an t_3. Those are connected to the AE33!
   df <- ds |>
     filter(1==0) |>
+    select(-rh_3, -t_3) |>
     collect()
   opts_dryer <- colnames(df)
   
@@ -150,17 +152,19 @@ acsmServer <- function(id, site) {
     get_ds <- reactive({
       
       # want the time range to match the data from the other tables
+      # remove rh_3 and t_3 because they are associated with ae33
       r <- get_range()
       min_dt <- min(r$start_date)
       max_dt <- max(r$start_date)
       df <- ds |>
         inner_join(select(tbl_sites, site_number, site_code), by = "site_number") |>
+        select(-t_3, -rh_3) |>
         filter(site_code == !!site(),
                datetime >= min_dt,
                datetime <= max_dt) |>
         collect()
       validate(need(nrow(df) > 0, "No data for site"))
-      
+
       df
       
       

--- a/services/r/ascentr/inst/apps/ascent-operations/R/ae33.R
+++ b/services/r/ascentr/inst/apps/ascent-operations/R/ae33.R
@@ -49,7 +49,7 @@ ae33UI <- function(id) {
       width = 1/2,
       gap = "8px",
       card(
-        selectInput(ns("plot_y"), label = "Label", choices = ae33_fields, multiple = TRUE,
+        selectInput(ns("plot_y"), label = "Label", choices = ae33_choices, multiple = TRUE,
                     selected = "tpcnt"),
         plotlyOutput(ns("ts_plot")),
         full_screen = TRUE
@@ -125,6 +125,25 @@ ae33Server <- function(id, site) {
       df <- purrr::map(df_list, clean_fields) |>
         purrr::reduce(\(x, y) inner_join(x, y, by = "time"))
       
+      
+    })
+    
+    # t_3 and rh_3 from dryerstats are the temp and rh probe connected to AE33
+    get_recent_rh_t <- reactive({
+      
+      # want the time range to match the data from the influx db
+      r <- get_recent()
+      min_dt <- min(as.POSIXct(r$time, tz = "UTC"))
+      max_dt <- max(as.POSIXct(r$time, tz = "UTC"))
+      df <- tbl(con, I("acsm.dryer_stats")) |>
+        inner_join(select(tbl_sites, site_number, site_code), by = "site_number") |>
+        select(datetime, site_code, t_3, rh_3) |>
+        filter(site_code == !!site(),
+               datetime >= min_dt,
+               datetime <= max_dt) |>
+        collect()
+
+      df
       
     })
     
@@ -295,12 +314,31 @@ ae33Server <- function(id, site) {
       
       df <- get_recent()
       validate(need(nrow(df > 0), "No data in time period"))
+      
+      # RH and T from dryerstats
+      if (any(input$plot_y %in% c("rh_3", "t_3"))) {
+        ds <- get_recent_rh_t() |>
+          select(time=datetime, any_of(input$plot_y)) |>
+          tidyr::pivot_longer(any_of(input$plot_y), names_to = "param", values_to = "value")
+      } else {
+        ds <- NULL
+      }
 
-      df <- df |>
-        select(time, any_of(input$plot_y)) |>
-        mutate(time = as.POSIXct(time, tz = "UTC")) |>
-        mutate(across(bit64::is.integer64, bit64::as.integer.integer64)) |>
-        tidyr::pivot_longer(any_of(input$plot_y), names_to = "param", values_to = "value")
+      if (any(input$plot_y %in% ae33_fields)) {
+        df <- df |>
+          select(time, any_of(input$plot_y)) |>
+          mutate(time = as.POSIXct(time, tz = "UTC")) |>
+          mutate(across(bit64::is.integer64, bit64::as.integer.integer64)) |>
+          tidyr::pivot_longer(any_of(input$plot_y), names_to = "param", values_to = "value")
+      } else {
+        df <- NULL
+      }
+      
+      validate(need(!is.null(df) | !is.null(ds), "No data for selected"))
+
+      df <- bind_rows(df, ds)
+      
+      validate(need(nrow(df) > 0, "No data for time period/parameter"))
 
       g <- ggplot(df, aes(x = time, y = value, color = param)) + geom_line() +
           scale_x_datetime(labels = scales::label_date()) +

--- a/services/r/ascentr/inst/apps/ascent-operations/global.R
+++ b/services/r/ascentr/inst/apps/ascent-operations/global.R
@@ -97,6 +97,9 @@ ae33_fields <- c("BB", "EBC1_1",
                  "sens1_5", "sens1_6", "sens1_7", "sens2_1", "sens2_2", "sens2_3", 
                  "sens2_4", "sens2_5", "sens2_6", "sens2_7", "tpcnt")
 
+# In addition to whats in influx, we also have the temp and rh from dryerstats!
+ae33_choices <- c(ae33_fields, "t_3", "rh_3")
+
 # Convert the AE33 STinst field from decimal to bits and return the statuses. These are
 # described in the AE33 user's manual ver 1.59, page 53
 parse_ae33_flags <- function(x) {


### PR DESCRIPTION
- Move the t_3 and rh_3 variables from dryerstats out of ACSM tab of ascent-operations and into the AE33 tab.  t_3 and rh_3 come from the temperature/humidity probe for the AE33.
- Add a correction to the ACSM L2 processing for RIE as requested by SOP team.